### PR TITLE
リファクタリングとMavenなど

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     </properties>
 
     <build>
+        <finalName>${project.name}</finalName>
         <defaultGoal>clean package</defaultGoal>
         <plugins>
             <plugin>
@@ -26,23 +27,6 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <finalName>${project.name}</finalName>
-                            <minimizeJar>true</minimizeJar>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
         <resources>

--- a/src/main/java/pw/riku/notileentity/Configuration.java
+++ b/src/main/java/pw/riku/notileentity/Configuration.java
@@ -1,0 +1,101 @@
+package pw.riku.notileentity;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * 設定を管理するためのクラスです。
+ */
+public class Configuration {
+    /**
+     * 読み込み対象
+     */
+    private final Path filePath;
+
+    /**
+     * 対象のエンティティリスト
+     */
+    private Set<Material> targetBlocks;
+
+    public Configuration(Path filePath) throws IOException, InvalidConfigurationException {
+        this.filePath = filePath;
+        load();
+    }
+
+    /**
+     * 設定を設定ファイルから読み込みます。
+     *
+     * @throws IOException                   入出力エラーが発生した場合
+     * @throws InvalidConfigurationException 無効な設定ファイルだった場合
+     */
+    public void load() throws IOException, InvalidConfigurationException {
+        org.bukkit.configuration.Configuration configuration = loadConfiguration();
+
+        loadTargetBlocks(configuration);
+    }
+
+    /**
+     * 対象のブロックリストを読み込みます。
+     *
+     * @param configuration Configuration
+     * @throws InvalidConfigurationException 無効な設定ファイルだった場合
+     */
+    private void loadTargetBlocks(org.bukkit.configuration.Configuration configuration)
+        throws InvalidConfigurationException {
+
+        targetBlocks = EnumSet.noneOf(Material.class);
+
+        for (String blocks : configuration.getStringList("blocks")) {
+            Material material;
+            try {
+                material = Material.valueOf(blocks);
+            } catch (IllegalArgumentException e) {
+                throw new InvalidConfigurationException("'" + blocks + "' is invalid material name!");
+            }
+            targetBlocks.add(material);
+        }
+    }
+
+    /**
+     * filePathを読み込みます。
+     *
+     * @return ロード済みのFileConfiguration
+     * @throws IOException                   入出力エラーが発生した場合
+     * @throws InvalidConfigurationException 無効な設定ファイルだった場合
+     */
+    private org.bukkit.configuration.Configuration loadConfiguration()
+        throws IOException, InvalidConfigurationException {
+
+        YamlConfiguration configuration = new YamlConfiguration();
+        try (BufferedReader reader = Files.newBufferedReader(filePath)) {
+            configuration.load(reader);
+        }
+        return configuration;
+    }
+
+    /**
+     * このクラスの読み込み対象となっている設定ファイルを返します。
+     *
+     * @return Path
+     */
+    public Path getFilePath() {
+        return filePath;
+    }
+
+    /**
+     * 対象のブロックリストを返します。
+     *
+     * @return ブロックリスト
+     */
+    public Set<Material> getTargetBlocks() {
+        return targetBlocks;
+    }
+}

--- a/src/main/java/pw/riku/notileentity/NoTileEntity.java
+++ b/src/main/java/pw/riku/notileentity/NoTileEntity.java
@@ -8,24 +8,35 @@ import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.wrappers.BlockPosition;
 import com.comphenix.protocol.wrappers.nbt.NbtBase;
 import com.comphenix.protocol.wrappers.nbt.NbtCompound;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.*;
+import java.io.*;
 
 public final class NoTileEntity extends JavaPlugin {
 
     private Set<UUID> players = new HashSet<>();
-    private List<String> blocks;
+    private Configuration configuration;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
-        blocks = getConfig().getStringList("blocks");
+        try {
+            configuration = new Configuration(getDataFolder().toPath().resolve("config.yml"));
+        } catch (IOException | InvalidConfigurationException e) {
+            getLogger().severe("Failed to load configuration file! disabling NoTileEntity");
+            e.printStackTrace();
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
         ProtocolManager manager = ProtocolLibrary.getProtocolManager();
         manager.addPacketListener(new PacketAdapter(this, PacketType.Play.Server.TILE_ENTITY_DATA) {
             @Override
@@ -33,7 +44,7 @@ public final class NoTileEntity extends JavaPlugin {
                 if (players.contains(event.getPlayer().getUniqueId())) {
                     BlockPosition position = event.getPacket().getBlockPositionModifier().read(0);
                     Material material = position.toLocation(event.getPlayer().getWorld()).getBlock().getType();
-                    if (blocks.contains(material.name())) {
+                    if (configuration.getTargetBlocks().contains(material)) {
                         event.setCancelled(true);
                     }
                 }
@@ -53,7 +64,7 @@ public final class NoTileEntity extends JavaPlugin {
                             int y = compound.getInteger("y");
                             int z = compound.getInteger("z");
                             Material material = new Location(event.getPlayer().getWorld(), x, y, z).getBlock().getType();
-                            if (blocks.contains(material.name())) {
+                            if (configuration.getTargetBlocks().contains(material)) {
                                 iterator.remove();
                             }
                         }
@@ -67,8 +78,7 @@ public final class NoTileEntity extends JavaPlugin {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player)) {
-            reloadConfig();
-            sender.sendMessage("reload complete!");
+            reloadAsync(sender);
             return true;
         }
 
@@ -91,9 +101,7 @@ public final class NoTileEntity extends JavaPlugin {
                 }
                 case "reload": {
                     if (player.hasPermission("notileentity.admin")) {
-                        reloadConfig();
-                        blocks = getConfig().getStringList("blocks");
-                        sender.sendMessage("reload complete!");
+                        reloadAsync(sender);
                         break;
                     }
                 }
@@ -113,5 +121,19 @@ public final class NoTileEntity extends JavaPlugin {
             players.add(uuid);
             return true;
         }
+    }
+
+    private void reloadAsync(CommandSender receiver) {
+        Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+            try {
+                configuration.load();
+            } catch (IOException | InvalidConfigurationException e) {
+                getLogger().warning("Failed to load configuration file!");
+                e.printStackTrace();
+                receiver.sendMessage("reload failed!");
+                return;
+            }
+            receiver.sendMessage("reload complete!");
+        });
     }
 }


### PR DESCRIPTION
- Mavenのプラグインからmaven-shade-pluginを削除しました。代わりに`project.build.finalName`で名前変更を行うようにしました。
- 設定ファイルの管理を別のクラスでまとめて行うことで以後の機能追加を簡単にしました。
- 設定ファイルのリロードを非同期で行うようにしました。
- 設定ファイルのロード時にエラーが発生した場合にログを出力するようにしました。
- 対象エンティティの管理にStringでなくMaterialを使用するようにしました。(この変更によって、設定ファイルにMaterialクラスに存在しない文字列が存在する場合にエラーが発生するようになりました。)